### PR TITLE
Avoid emulation slowdown when encoder outputs are low

### DIFF
--- a/examples/board_ayab/ayab.c
+++ b/examples/board_ayab/ayab.c
@@ -30,6 +30,7 @@
 #include "avr_ioport.h"
 #include "avr_adc.h"
 #include "avr_twi.h"
+#include "avr_extint.h"
 #include "sim_elf.h"
 #include "sim_hex.h"
 #include "sim_gdb.h"
@@ -246,6 +247,12 @@ static void * avr_run_thread(void * param)
 #if AVR_STACK_WATCH
     uint16_t SP_min = (avr->data[R_SPH]<<8) +  avr->data[R_SPL];
 #endif
+
+    // This makes emulation slightly faster (and more significantly, more regular)
+    // by avoiding a repeated check for level-triggered interrupts
+    // (which AYAB does't use anyway) when Arduino pins 2 or 3 are set to low.
+    avr_extint_set_strict_lvl_trig(avr, 0, 0);
+    avr_extint_set_strict_lvl_trig(avr, 1, 0);
 
     // Initialize VCD for PC-only traces
     if (!avr->vcd && (trace_pc || trace_machine)) {


### PR DESCRIPTION
I spent a while today digging into this weird fluctuation in emulation speed, so I figured I'd make a PR with my findings, do with it what you will!

## Problem

There's an obscure bit of behavior in the Atmega where external interrupts can be level-triggered i.e. keep firing while the input pin is being held low.
Due to simavr's architecture this has an emulation cost even when an external interrupt is not enabled. See this note in the code: https://github.com/jpcornil-git/simavr/blob/cecc6e8f30ea7025afcc8a29b2f4dc27ebf86475/simavr/sim/avr_extint.c#L132-L141

As a result, emulation runs slower (about 50% slower on my machine) whenever the V2 encoder output is being held low by the simulated machine.

Note that the V1 encoder output (on pin 2, using external interrupt `INT0`) is not normally affected because the firmware does configure that interrupt to be edge-triggered. But pin 3 is left to the default level-triggered status, and as described above this causes extra code to execute even if the interrupt is never used by the firmware.

## Proposed solution

By using the provided `avr_extint_set_strict_lvl_trig` function to relax conformance requirements, we can avoid this slowdown.