### PR TITLE
Add 'R' key to reset arduino

### DIFF
--- a/examples/board_ayab/ayab.c
+++ b/examples/board_ayab/ayab.c
@@ -314,6 +314,10 @@ static void * avr_run_thread(void * param)
                 unsigned new_phase = encoder_phase;
                 switch (event)
                 {
+                    case RESET_ARDUINO:
+                        fprintf(stderr, "Resetting Arduino\n");
+                        avr_reset(avr);
+                        break;
                     case CARRIAGE_LEFT:
                         new_phase = (encoder_phase-1)%64;
                         if ((new_phase%4) == 0) {

--- a/examples/board_ayab/ayab_display.c
+++ b/examples/board_ayab/ayab_display.c
@@ -101,6 +101,11 @@ keyCB (unsigned char key, int x, int y)
             // ... and exit
             exit(0);
 			break;
+
+		case 'r':
+            queue_push(&event_queue, RESET_ARDUINO, 0);
+            break;
+
 		case 'v':
             queue_push(&event_queue, VCD_DUMP, 0);
 			break;

--- a/examples/board_ayab/queue.h
+++ b/examples/board_ayab/queue.h
@@ -6,6 +6,7 @@ enum event_type {
     CARRIAGE_LEFT,
     CARRIAGE_RIGHT,
     VCD_DUMP,
+    RESET_ARDUINO,
 };
 
 typedef struct {


### PR DESCRIPTION
## Problem

The current `ayab-firmware` does not behave well when the desktop app stops (either by canceling or finishing) and then restarts knitting without a reset in between.

This is not a problem in hardware since opening the serial port triggers an Arduino reset, but with `simavr` it fails — the desktop app gets stuck in a loop of "Error initializing firmware". The only way out is to restart `simavr` which can be inconvenient in repeated testing.

## Proposed solution

Ideally we could detect the PTY being opened but this seems to be a bit involved actually, and it would require modifications to `uart_pty`.
Instead this PR simply adds an `R` key that resets the Arduino.